### PR TITLE
Augments maximum method name length and adds support for methods with more than 16 parameters

### DIFF
--- a/src/vm/wren_common.h
+++ b/src/vm/wren_common.h
@@ -88,7 +88,7 @@
 // The maximum name of a method, not including the signature. This is an
 // arbitrary but enforced maximum just so we know how long the method name
 // strings need to be in the parser.
-#define MAX_METHOD_NAME 64
+#define MAX_METHOD_NAME 128
 
 // The maximum length of a method signature. Signatures look like:
 //

--- a/src/vm/wren_common.h
+++ b/src/vm/wren_common.h
@@ -80,10 +80,11 @@
 // `CODE_LOAD_MODULE_VAR` and `CODE_STORE_MODULE_VAR`.
 #define MAX_MODULE_VARS 65536
 
-// The maximum number of arguments that can be passed to a method. Note that
-// this limitation is hardcoded in other places in the VM, in particular, the
-// `CODE_CALL_XX` instructions assume a certain maximum number.
-#define MAX_PARAMETERS 16
+// The maximum number of arguments that can be passed to a method.
+// When the number of parameters is superior to 16
+// a whole byte is used for passing the number of args,
+// making the max 254 + 1 (1 arg is reserved for the receiver)
+#define MAX_PARAMETERS 254
 
 // The maximum name of a method, not including the signature. This is an
 // arbitrary but enforced maximum just so we know how long the method name

--- a/src/vm/wren_compiler.c
+++ b/src/vm/wren_compiler.c
@@ -3487,6 +3487,7 @@ static bool method(Compiler* compiler, Variable classVariable)
   }
   else
   {
+    ignoreNewlines(compiler);
     consume(compiler, TOKEN_LEFT_BRACE, "Expect '{' to begin method body.");
     finishBody(&methodCompiler);
     endCompiler(&methodCompiler, fullSignature, length);
@@ -3584,6 +3585,7 @@ static void classDefinition(Compiler* compiler, bool isForeign)
   compiler->enclosingClass = &classInfo;
 
   // Compile the method definitions.
+  ignoreNewlines(compiler);
   consume(compiler, TOKEN_LEFT_BRACE, "Expect '{' after class declaration.");
   matchLine(compiler);
 

--- a/src/vm/wren_debug.c
+++ b/src/vm/wren_debug.c
@@ -202,6 +202,14 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
              vm->methodNames.data[symbol]->value);
       break;
     }
+    case CODE_CALL_17PLUS:
+    {
+      uint8_t numArgs = READ_BYTE();
+      int symbol = READ_SHORT();
+      printf("CALL_%-11d %5d '%s'\n", numArgs, symbol,
+             vm->methodNames.data[symbol]->value);
+      break;
+    }
 
     case CODE_SUPER_0:
     case CODE_SUPER_1:
@@ -222,6 +230,15 @@ static int dumpInstruction(WrenVM* vm, ObjFn* fn, int i, int* lastLine)
     case CODE_SUPER_16:
     {
       int numArgs = bytecode[i - 1] - CODE_SUPER_0;
+      int symbol = READ_SHORT();
+      int superclass = READ_SHORT();
+      printf("SUPER_%-10d %5d '%s' %5d\n", numArgs, symbol,
+             vm->methodNames.data[symbol]->value, superclass);
+      break;
+    }
+    case CODE_SUPER_17PLUS:
+    {
+      int numArgs = READ_BYTE();
       int symbol = READ_SHORT();
       int superclass = READ_SHORT();
       printf("SUPER_%-10d %5d '%s' %5d\n", numArgs, symbol,

--- a/src/vm/wren_opcodes.h
+++ b/src/vm/wren_opcodes.h
@@ -96,6 +96,7 @@ OPCODE(CALL_13, -13)
 OPCODE(CALL_14, -14)
 OPCODE(CALL_15, -15)
 OPCODE(CALL_16, -16)
+OPCODE(CALL_17PLUS, -17)
 
 // Invoke a superclass method with symbol [arg]. The number indicates the
 // number of arguments (not including the receiver).
@@ -116,6 +117,7 @@ OPCODE(SUPER_13, -13)
 OPCODE(SUPER_14, -14)
 OPCODE(SUPER_15, -15)
 OPCODE(SUPER_16, -16)
+OPCODE(SUPER_17PLUS, -17)
 
 // Jump the instruction pointer [arg] forward.
 OPCODE(JUMP, 0)


### PR DESCRIPTION
Also allows `{` on new line for class declaration and declaring method body.

As far as I know allowing `{` for other stuff too would be breaking due to the language allowing to skip using `()` for calling methods